### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
@@ -50,6 +52,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: test
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/Eoic/ASCIIGround/security/code-scanning/2](https://github.com/Eoic/ASCIIGround/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for each job. For this workflow:

1. The `test` job primarily reads repository contents and runs tests, so it only needs `contents: read`.
2. The `build` job also reads repository contents and uploads artifacts, so it only needs `contents: read`.

The `permissions` block can be added at the job level for both `test` and `build` jobs to ensure each job has the minimum required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
