### PR TITLE
fix: update canvas size from the resizeTo target upon initialization

### DIFF
--- a/src/__tests__/asciiground.test.ts
+++ b/src/__tests__/asciiground.test.ts
@@ -24,8 +24,8 @@ describe('ASCIIGround', () => {
         vi.clearAllMocks();
         mockRequestAnimationFrame.mockImplementation((_callback: FrameRequestCallback) => 123);
         canvas = document.createElement('canvas');
-        canvas.width = 800;
-        canvas.height = 600;
+        window.innerWidth = 800;
+        window.innerHeight = 600;
         pattern = new DummyPattern();
     });
 
@@ -226,8 +226,8 @@ describe('ASCIIGround', () => {
         });
 
         it('should handle very large canvas', () => {
-            canvas.width = 4000;
-            canvas.height = 3000;
+            window.innerWidth = 4000;
+            window.innerHeight = 3000;
 
             const asciiGround = new ASCIIGround();
             expect(() => asciiGround.init(canvas, pattern)).not.toThrow();

--- a/src/demo/demo.ts
+++ b/src/demo/demo.ts
@@ -6,9 +6,6 @@ import { ASCIIRenderer } from '../rendering/ascii-renderer';
 (() => {
     function start() {
         const canvas = document.createElement('canvas');
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
-
         const renderer = new ASCIIRenderer(canvas);
         const loader = document.getElementById('loader') as HTMLElement;
         const controls = document.getElementById('controls') as HTMLFormElement;

--- a/src/rendering/ascii-renderer.ts
+++ b/src/rendering/ascii-renderer.ts
@@ -120,6 +120,15 @@ export class ASCIIRenderer {
         return this._state.canvas;
     }
 
+    private get resizeDimensions(): [ width: number, height: number ] {
+        const target = this._state.options.resizeTo;
+
+        if (target instanceof HTMLElement)
+            return [target.clientWidth, target.clientHeight];
+
+        return [target.innerWidth, target.innerHeight];
+    }
+
     /**
      * Get the renderer, throwing an error if not initialized.
      */
@@ -267,18 +276,9 @@ export class ASCIIRenderer {
      * Resize the canvas and recalculate layout.
      */
     public resize(): void {
-        const width = this._state.options.resizeTo instanceof HTMLElement
-            ? this._state.options.resizeTo.clientWidth
-            : this._state.options.resizeTo.innerWidth;
-
-        const height = this._state.options.resizeTo instanceof HTMLElement
-            ? this._state.options.resizeTo.clientHeight
-            : this._state.options.resizeTo.innerHeight;
-
-        this.canvas.width = width;
-        this.canvas.height = height;
+        [this.canvas.width, this.canvas.height] = this.resizeDimensions;
         this._state.region = this._calculateRegion();
-        this.renderer.resize(width, height);
+        this.renderer.resize(this.canvas.width, this.canvas.height);
         this.pattern.initialize(this._state.region);
 
         if (!this.isAnimating) {
@@ -360,6 +360,7 @@ export class ASCIIRenderer {
      * This sets up the rendering context and prepares for rendering.
      */
     private _setupRenderer(): void {
+        [this.canvas.width, this.canvas.height] = this.resizeDimensions;
         this.renderer.initialize(this.canvas, this._state.options);
         this.pattern.initialize(this.region);
 


### PR DESCRIPTION
Fix an issue where the canvas element was not resized to the `resizeTo` target (`window` by default) size on initialization.