### PR TITLE
Fix canvas resizing issues.

### DIFF
--- a/docs/styles/common.css
+++ b/docs/styles/common.css
@@ -10,6 +10,10 @@ body {
     background-color: #292929;
 }
 
+* {
+    box-sizing: border-box;
+}
+
 /* Text and color utilities */
 .text-muted {
     color: #ddd;

--- a/docs/styles/demo.css
+++ b/docs/styles/demo.css
@@ -399,6 +399,11 @@ canvas {
     display: block;
 }
 
+#canvas-container {
+    width: 100%;
+    height: 100%;
+}
+
 .loading {
     position: fixed;
     top: 50%;

--- a/src/__tests__/asciirenderer.test.ts
+++ b/src/__tests__/asciirenderer.test.ts
@@ -46,7 +46,7 @@ describe('ASCIIRenderer', () => {
 
     describe('constructor', () => {
         it('should create ASCIIRenderer instance with default options', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
             expect(renderer.pattern).toBe(pattern);
@@ -60,7 +60,7 @@ describe('ASCIIRenderer', () => {
                 fontFamily: 'courier',
             };
             
-            const renderer = new ASCIIRenderer(canvas, pattern, options);
+            const renderer = new ASCIIRenderer({ canvas, pattern, options });
             
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
             expect(mockContext.font).toBe('16px courier');
@@ -69,13 +69,13 @@ describe('ASCIIRenderer', () => {
         it('should throw error if canvas context is not available', () => {
             vi.spyOn(canvas, 'getContext').mockReturnValue(null);
             
-            expect(() => new ASCIIRenderer(canvas, pattern)).toThrow('Could not get 2D context from canvas');
+            expect(() => new ASCIIRenderer({ canvas, pattern })).toThrow('Could not get 2D context from canvas');
         });
     });
 
     describe('pattern management', () => {
         it('should set and get pattern', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             const newPattern = new PerlinNoisePattern();
             
             renderer.pattern = newPattern;
@@ -83,7 +83,7 @@ describe('ASCIIRenderer', () => {
         });
 
         it('should initialize pattern when set', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             const newPattern = new PerlinNoisePattern();
             const initializeSpy = vi.spyOn(newPattern, 'initialize');
             
@@ -94,14 +94,14 @@ describe('ASCIIRenderer', () => {
 
     describe('animation control', () => {
         it('should start animation', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             renderer.startAnimation();
             expect(mockRequestAnimationFrame).toHaveBeenCalled();
         });
 
         it('should stop animation', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             renderer.startAnimation();
             renderer.stopAnimation();
@@ -109,7 +109,7 @@ describe('ASCIIRenderer', () => {
         });
 
         it('should not start animation if already running', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             renderer.startAnimation();
             mockRequestAnimationFrame.mockClear();
@@ -118,7 +118,7 @@ describe('ASCIIRenderer', () => {
         });
 
         it('should handle multiple stop calls gracefully', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             renderer.startAnimation();
             renderer.stopAnimation();
@@ -129,7 +129,7 @@ describe('ASCIIRenderer', () => {
 
     describe('options management', () => {
         it('should update options', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             renderer.setOptions({
                 fontSize: 20,
@@ -140,24 +140,27 @@ describe('ASCIIRenderer', () => {
         });
 
         it('should handle padding option', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern, { padding: 10 });
-            
+            const renderer = new ASCIIRenderer({ canvas, pattern, options: { padding: 10 } });
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
         });
 
         it('should handle custom character spacing', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern, {
-                charSpacingX: 15,
-                charSpacingY: 20,
+            const renderer = new ASCIIRenderer({
+                canvas,
+                pattern,
+                options: {
+                    charSpacingX: 15,
+                    charSpacingY: 20,
+                },
             });
-            
+
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
         });
     });
 
     describe('resize functionality', () => {
         it('should resize canvas', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             renderer.resize();
             expect(canvas.width).toBeGreaterThan(0);
             expect(canvas.height).toBeGreaterThan(0);
@@ -166,7 +169,7 @@ describe('ASCIIRenderer', () => {
         });
 
         it('should recalculate grid on resize', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             const initializeSpy = vi.spyOn(pattern, 'initialize');
             
             canvas.width = 1200;
@@ -179,10 +182,8 @@ describe('ASCIIRenderer', () => {
 
     describe('mouse interaction', () => {
         it('should handle mouse events when enabled', () => {
-            new ASCIIRenderer(canvas, pattern, {
-                enableMouseInteraction: true,
-            });
-            
+            new ASCIIRenderer({canvas, pattern, options: { enableMouseInteraction: true }});
+
             const mouseEvent = new MouseEvent('mousemove', {
                 clientX: 100,
                 clientY: 200,
@@ -195,11 +196,7 @@ describe('ASCIIRenderer', () => {
 
         it('should not add mouse listeners when disabled', () => {
             const addEventListenerSpy = vi.spyOn(canvas, 'addEventListener');
-            
-            new ASCIIRenderer(canvas, pattern, {
-                enableMouseInteraction: false,
-            });
-            
+            new ASCIIRenderer({ canvas, pattern, options: { enableMouseInteraction: false } });
             expect(addEventListenerSpy).not.toHaveBeenCalledWith('mousemove', expect.any(Function));
         });
     });
@@ -209,15 +206,15 @@ describe('ASCIIRenderer', () => {
             const perlinPattern = new PerlinNoisePattern();
             
             expect(() => {
-                new ASCIIRenderer(canvas, perlinPattern);
+                new ASCIIRenderer({canvas, pattern: perlinPattern });
             }).not.toThrow();
         });
 
         it('should work with RainPattern', () => {
             const rainPattern = new RainPattern();
-            
+
             expect(() => {
-                new ASCIIRenderer(canvas, rainPattern);
+                new ASCIIRenderer({ canvas, pattern: rainPattern });
             }).not.toThrow();
         });
 
@@ -225,14 +222,14 @@ describe('ASCIIRenderer', () => {
             const staticPattern = new StaticNoisePattern();
             
             expect(() => {
-                new ASCIIRenderer(canvas, staticPattern);
+                new ASCIIRenderer({ canvas, pattern: staticPattern });
             }).not.toThrow();
         });
     });
 
     describe('rendering', () => {
         it('should render frame without errors', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             expect(() => {
                 renderer.render();
@@ -245,25 +242,27 @@ describe('ASCIIRenderer', () => {
             const fontSizes = [8, 12, 16, 24, 32];
             
             fontSizes.forEach(fontSize => {
-                new ASCIIRenderer(canvas, pattern, { fontSize });
+                new ASCIIRenderer({ canvas, pattern, options: { fontSize }});
                 expect(mockContext.font).toContain(`${fontSize}px`);
             });
         });
 
         it('should handle different colors', () => {
             const colors = ['#ff0000', '#00ff00', '#0000ff', '#ffffff'];
-            colors.forEach((color) => new ASCIIRenderer(canvas, pattern, { color }));
+            colors.forEach((color) => new ASCIIRenderer({ canvas, pattern, options: { color } }));
         });
     });
 
     describe('destruction', () => {
         it('should clean up resources on destroy', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern, {
-                enableMouseInteraction: true,
+            const renderer = new ASCIIRenderer({
+                canvas,
+                pattern,
+                options: { enableMouseInteraction: true },
             });
-            
+
             renderer.startAnimation();
-            
+
             expect(() => {
                 renderer.destroy();
             }).not.toThrow();
@@ -274,24 +273,26 @@ describe('ASCIIRenderer', () => {
         it('should remove event listeners on destroy', () => {
             const removeEventListenerSpy = vi.spyOn(canvas, 'removeEventListener');
             
-            const renderer = new ASCIIRenderer(canvas, pattern, {
-                enableMouseInteraction: true,
+            const renderer = new ASCIIRenderer({
+                canvas,
+                pattern, 
+                options: { enableMouseInteraction: true },
             });
-            
+
             renderer.destroy();
-            
+
             expect(removeEventListenerSpy).toHaveBeenCalled();
         });
     });
 
     describe('renderer types', () => {
         it('should handle 2D renderer type', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern, { rendererType: '2D' });
+            const renderer = new ASCIIRenderer({ canvas, pattern, options: { rendererType: '2D' } });
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
         });
 
         it('should handle WebGL renderer type', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern, { rendererType: 'WebGL' });
+            const renderer = new ASCIIRenderer({ canvas, pattern, options: { rendererType: 'WebGL' } });
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
         });
     });
@@ -301,7 +302,7 @@ describe('ASCIIRenderer', () => {
             const speeds = [0.5, 1.0, 2.0, 5.0];
 
             speeds.forEach(animationSpeed => {
-                const renderer = new ASCIIRenderer(canvas, pattern, { animationSpeed });
+                const renderer = new ASCIIRenderer({ canvas, pattern, options: { animationSpeed } });
                 expect(renderer).toBeInstanceOf(ASCIIRenderer);
             });
         });
@@ -312,7 +313,7 @@ describe('ASCIIRenderer', () => {
             canvas.width = 10;
             canvas.height = 10;
 
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
         });
 
@@ -320,24 +321,24 @@ describe('ASCIIRenderer', () => {
             canvas.width = 4000;
             canvas.height = 3000;
             
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
         });
 
         it('should handle zero padding', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern, { padding: 0 });
+            const renderer = new ASCIIRenderer({ canvas, pattern, options: { padding: 0 } });
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
         });
 
         it('should handle large padding', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern, { padding: 10000 });
+            const renderer = new ASCIIRenderer({ canvas, pattern, options: { padding: 10000 } });
             expect(renderer).toBeInstanceOf(ASCIIRenderer);
         });
     });
 
     describe('character transformations', () => {
         it('should handle character with opacity', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             // Test using public render method with pattern that generates characters with opacity
             pattern.generate = vi.fn(() => [
@@ -350,7 +351,7 @@ describe('ASCIIRenderer', () => {
         });
 
         it('should handle character with color', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             pattern.generate = vi.fn(() => [
                 { x: 10, y: 20, char: 'A', color: '#ff0000' }
@@ -362,7 +363,7 @@ describe('ASCIIRenderer', () => {
         });
 
         it('should handle character transformations', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             pattern.generate = vi.fn(() => [
                 { x: 10, y: 20, char: 'A', scale: 1.5, rotation: Math.PI / 4 }
@@ -374,7 +375,7 @@ describe('ASCIIRenderer', () => {
         });
 
         it('should handle out of bounds characters', () => {
-            const renderer = new ASCIIRenderer(canvas, pattern);
+            const renderer = new ASCIIRenderer({ canvas, pattern });
             
             pattern.generate = vi.fn(() => [
                 { x: -10, y: 20, char: 'A' }, // Outside bounds

--- a/src/__tests__/demo/demo-main.test.ts
+++ b/src/__tests__/demo/demo-main.test.ts
@@ -4,9 +4,7 @@ interface MockDocument {
     createElement: ReturnType<typeof vi.fn>;
     getElementById: ReturnType<typeof vi.fn>;
     addEventListener: ReturnType<typeof vi.fn>;
-    body: {
-        appendChild: ReturnType<typeof vi.fn>;
-    };
+    body: { appendChild: ReturnType<typeof vi.fn> };
 }
 
 describe('Demo.ts Coverage Test', () => {
@@ -15,7 +13,7 @@ describe('Demo.ts Coverage Test', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.resetModules();
-        
+
         const mockCanvas = {
             width: 0,
             height: 0,
@@ -144,13 +142,13 @@ describe('Demo.ts Coverage Test', () => {
         expect(addEventListenerMock).toHaveBeenCalledWith('DOMContentLoaded', expect.anything());
 
         const calls = vi.mocked(addEventListenerMock).mock.calls;
-        const domLoadedCall = calls.find(call => call[0] === 'DOMContentLoaded');
+        const domLoadedCall = calls.find((call) => call[0] === 'DOMContentLoaded');
         expect(domLoadedCall).toBeDefined();
-        
+
         if (domLoadedCall) {
             const startFunction = domLoadedCall[1] as () => void;
             startFunction();
-            
+
             const createElementMock = mockDocument.createElement;
             expect(createElementMock).toHaveBeenCalledWith('canvas');
             

--- a/src/__tests__/demo/demo.test.ts
+++ b/src/__tests__/demo/demo.test.ts
@@ -93,7 +93,7 @@ describe('Demo - PatternControlsManager', () => {
         });
 
         const pattern = new DummyPattern();
-        renderer = new ASCIIRenderer(mockCanvas, pattern);
+        renderer = new ASCIIRenderer({ canvas: mockCanvas, pattern });
     });
 
     afterEach(() => {

--- a/src/__tests__/demo/pattern-proxy.test.ts
+++ b/src/__tests__/demo/pattern-proxy.test.ts
@@ -66,7 +66,7 @@ describe('PatternProxy', () => {
         });
 
         const pattern = new DummyPattern();
-        renderer = new ASCIIRenderer(mockCanvas, pattern);
+        renderer = new ASCIIRenderer({ canvas: mockCanvas, pattern });
         patternProxy = new PatternProxy(renderer);
     });
 

--- a/src/demo/demo.ts
+++ b/src/demo/demo.ts
@@ -5,12 +5,23 @@ import { ASCIIRenderer } from '../rendering/ascii-renderer';
 
 (() => {
     function start() {
-        const canvas = document.createElement('canvas');
-        const renderer = new ASCIIRenderer(canvas);
+        let canvas: HTMLCanvasElement | null = document.getElementById('canvas') as HTMLCanvasElement | null;
+
+        if (!canvas)
+            canvas = document.createElement('canvas');
+
+        let canvasContainer = document.getElementById('canvas-container') as HTMLDivElement | null;
+
+        if (!canvasContainer) {
+            canvasContainer = document.createElement('div');
+            canvasContainer.id = 'canvas-container';
+            canvasContainer.appendChild(canvas);
+            document.body.appendChild(canvasContainer);
+        }
+
+        const renderer = new ASCIIRenderer({ canvas, options: { resizeTo: canvasContainer } });
         const loader = document.getElementById('loader') as HTMLElement;
         const controls = document.getElementById('controls') as HTMLFormElement;
-
-        document.body.appendChild(canvas);
         handleControls(controls, renderer);
         removeLoader(loader);
     }

--- a/src/demo/index.eta
+++ b/src/demo/index.eta
@@ -28,6 +28,10 @@
         <h2 class="gradient-text">Controls</h2>
     </form>
 
+    <div id="canvas-container">
+        <canvas id="canvas"></canvas>
+    </div>
+
     <% scripts.forEach(function(scriptPath) { %>
         <% if (scriptPath.endsWith(".ts")) { %>
             <script type="module" src="<%= scriptPath %>"></script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export class ASCIIGround {
         pattern: Pattern,
         options?: Partial<ASCIIRendererOptions>
     ): ASCIIGround {
-        this.renderer = new ASCIIRenderer(canvas, pattern, options);
+        this.renderer = new ASCIIRenderer({ canvas, pattern, options });
         return this;
     }
 

--- a/src/rendering/ascii-renderer.ts
+++ b/src/rendering/ascii-renderer.ts
@@ -33,6 +33,17 @@ export interface ASCIIRendererOptions {
     resizeTo: Window | HTMLElement
 }
 
+/**
+ * Constructor options for the ASCIIRenderer.
+ * @category Rendering
+ * @see ASCIIRenderer
+ */
+export interface ASCIIRendererConstructor {
+    canvas: HTMLCanvasElement;
+    pattern?: Pattern;
+    options?: Partial<ASCIIRendererOptions>;
+}
+
 const DEFAULT_OPTIONS: ASCIIRendererOptions = {
     color: '#3e3e80ff',
     fontSize: 32,
@@ -168,12 +179,13 @@ export class ASCIIRenderer {
     }
 
     /**
-     * Create a new ASCII renderer.
-     * @param canvas - the canvas element to render to.
-     * @param pattern - the pattern generator to use.
-     * @param options - rendering options.
+     * Create a new ASCIIRenderer instance.
+     * @param options - the renderer constructor parameters.
      */
-    constructor(canvas: HTMLCanvasElement, pattern?: Pattern, options: Partial<ASCIIRendererOptions> = {}) {
+    constructor({ canvas, pattern, options }: ASCIIRendererConstructor) {
+        if (!options)
+            options = {};
+
         this._state.canvas = canvas;
         this._state.pattern = pattern || new DummyPattern();
         this._handleResize = this.resize.bind(this);


### PR DESCRIPTION
### CSS styling:
* Added a universal `box-sizing: border-box` rule in `docs/styles/common.css` to ensure consistent box model behavior across elements.
* Introduced a `#canvas-container` style in `docs/styles/demo.css` to set its width and height to 100%.

### `ASCIIRenderer`:
* Fixed an issue where canvas resizing did not account for padding if `resizeTo` target was `HTMLElement`.
* Updated all `ASCIIRenderer` test cases in `src/__tests__/asciirenderer.test.ts` to use an object-based constructor signature (`{ canvas, pattern, options }`) instead of positional arguments for improved readability.

### Demo environment:
* Update template to wrap canvas into canvas container HTML element.
* Use the newly added canvas container element as a `resizeTo` target.
* Mocked `getComputedStyle` and added a mock implementation for `HTMLElement` in `src/__tests__/demo/demo-execution.test.ts` to better simulate DOM behavior.
* Added mocks for `createRenderer` and `DummyPattern` modules to streamline testing of demo script execution.