### PR TITLE
fix(utils): normalize negative seeds

### DIFF
--- a/src/__tests__/utils/seeded-random.test.ts
+++ b/src/__tests__/utils/seeded-random.test.ts
@@ -37,6 +37,13 @@ describe('createSeededRandom', () => {
         expect(value).toBeLessThanOrEqual(1);
     });
 
+    it('should handle negative seed values by converting to positive', () => {
+        const random = createSeededRandom(-12345);
+        const value = random();
+        expect(value).toBeGreaterThan(0);
+        expect(value).toBeLessThanOrEqual(1);
+    });
+
     it('should produce consistent sequences across multiple calls', () => {
         const random = createSeededRandom(999);
         const firstCall = random();

--- a/src/utils/seeded-random.ts
+++ b/src/utils/seeded-random.ts
@@ -4,7 +4,9 @@
  * @returns A function that generates pseudo-random numbers between 0 and 1
  */
 export const createSeededRandom = (seed: number) => {
-    let state = seed === 0 ? 1 : seed;
+    let state = Math.floor(seed) % 2147483647;
+    if (state <= 0)
+        state += 2147483646;
 
     return () => {
         state = (state * 16807) % 2147483647;


### PR DESCRIPTION
## Summary
- ensure seeded random generator normalizes negative or zero seeds to a valid range
- test negative seed behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68950afbca0c832bbb89694f0d262071