### PR TITLE
feat: optimize canvas rendering loop

### DIFF
--- a/docs/styles/demo.css
+++ b/docs/styles/demo.css
@@ -54,6 +54,42 @@ body {
     min-width: 120px;
 }
 
+.controls .color-map-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.controls .color-map-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.controls .color-map-char {
+    width: 50px;
+    text-align: center;
+}
+
+.controls .color-map-color {
+    width: 40px;
+    padding: 0;
+}
+
+.controls .color-map-row button {
+    padding: 4px 8px;
+    font-size: 0.8rem;
+    grid-column: auto;
+}
+
+.controls .color-map-add {
+    margin-top: 8px;
+    padding: 6px 12px;
+    font-size: 0.8rem;
+    grid-column: auto;
+    align-self: flex-start;
+}
+
 /* Form input styling */
 .controls input[type="text"],
 .controls input[type="number"],

--- a/src/__tests__/asciirenderer.test.ts
+++ b/src/__tests__/asciirenderer.test.ts
@@ -352,14 +352,27 @@ describe('ASCIIRenderer', () => {
 
         it('should handle character with color', () => {
             const renderer = new ASCIIRenderer({ canvas, pattern });
-            
+
             pattern.generate = vi.fn(() => [
                 { x: 10, y: 20, char: 'A', color: '#ff0000' }
             ]);
-            
+
             expect(() => {
                 renderer.render();
             }).not.toThrow();
+        });
+
+        it('should apply color map for characters', () => {
+            const renderer = new ASCIIRenderer({ canvas, pattern, options: { colorMap: { '#': '#00ff00' } } });
+
+            pattern.generate = vi.fn(() => [
+                { x: 10, y: 20, char: '#' }
+            ]);
+
+            const fillSpy = vi.spyOn(mockContext, 'fillStyle', 'set');
+            renderer.render();
+
+            expect(fillSpy).toHaveBeenCalledWith('#00ff00');
         });
 
         it('should handle character transformations', () => {

--- a/src/__tests__/demo/controls-generator-dom.test.ts
+++ b/src/__tests__/demo/controls-generator-dom.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ControlsGenerator } from '../../demo/ui/controls-generator';
+
+// Tests focused on real DOM interactions for ControlsGenerator
+
+describe('ControlsGenerator DOM integration', () => {
+    let container: HTMLFormElement;
+    let generator: ControlsGenerator;
+
+    beforeEach(() => {
+        container = document.createElement('form');
+        document.body.appendChild(container);
+        generator = new ControlsGenerator(container);
+        generator.generatePatternControls('dummy');
+    });
+
+    afterEach(() => {
+        generator.destroy();
+        container.remove();
+    });
+
+    it('should handle color map editing and emit changes', () => {
+        const callback = vi.fn();
+        generator.onControlChange('colorMap', callback);
+
+        const addBtn = container.querySelector('label[data-control-id="colorMap"] .color-map-add') as HTMLButtonElement;
+        addBtn.click();
+
+        const charInput = container.querySelector('label[data-control-id="colorMap"] .color-map-char') as HTMLInputElement;
+        const colorInput = container.querySelector('label[data-control-id="colorMap"] .color-map-color') as HTMLInputElement;
+
+        charInput.value = '#';
+        charInput.dispatchEvent(new Event('input', { bubbles: true }));
+        colorInput.value = '#ff0000';
+        colorInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(callback).toHaveBeenLastCalledWith({ '#': '#ff0000' });
+        expect(generator.getControlValue('colorMap')).toEqual({ '#': '#ff0000' });
+    });
+
+    it('should toggle conditional control visibility', () => {
+        const animatedInput = container.querySelector('input[data-control-id="animated"]') as HTMLInputElement;
+        const speedLabel = container.querySelector('label[data-control-id="animationSpeed"]')!;
+        expect(speedLabel.classList.contains('hidden')).toBe(true);
+
+        animatedInput.checked = true;
+        animatedInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(speedLabel.classList.contains('hidden')).toBe(false);
+    });
+});
+

--- a/src/__tests__/demo/controls-registry-additional.test.ts
+++ b/src/__tests__/demo/controls-registry-additional.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { ControlsRegistry } from '../../demo/ui/controls/controls-registry';
+
+describe('ControlsRegistry additional', () => {
+    it('should get control spec by id', () => {
+        const spec = ControlsRegistry.getControlSpec('colorMap');
+        expect(spec).not.toBeNull();
+        expect(spec?.id).toBe('colorMap');
+    });
+
+    it('should return combined control specs', () => {
+        const specs = ControlsRegistry.getAllControlsSpecs();
+        const ids = specs.map(s => s.id);
+        expect(ids).toContain('colorMap');
+        expect(ids).toContain('rainDensity');
+    });
+
+    it('should parse out types correctly', () => {
+        expect(ControlsRegistry.parseOutType('true', 'boolean')).toBe(true);
+        expect(ControlsRegistry.parseOutType('42', 'number')).toBe(42);
+        expect(ControlsRegistry.parseOutType('ab', 'array')).toEqual(['a', 'b']);
+        const record = { a: '1' };
+        expect(ControlsRegistry.parseOutType(record, 'record')).toEqual(record);
+        expect(ControlsRegistry.parseOutType('foo', 'string')).toBe('foo');
+    });
+
+    it('should get pattern options with parsed types', () => {
+        const options = ControlsRegistry.getPatternOptions('perlin-noise');
+        expect(typeof options.frequency).toBe('number');
+        expect(options).toHaveProperty('frequency');
+    });
+
+    it('should get renderer options with defaults', () => {
+        const options = ControlsRegistry.getRendererOptions();
+        expect(options).toHaveProperty('fontSize');
+        expect(options).toHaveProperty('colorMap');
+        expect(options.colorMap).toEqual({});
+    });
+
+    it('should list available patterns', () => {
+        const patterns = ControlsRegistry.getAvailablePatterns().map(p => p.value);
+        ['perlin-noise', 'rain', 'static', 'dummy'].forEach(id => expect(patterns).toContain(id));
+    });
+});

--- a/src/__tests__/demo/ui-controls.test.ts
+++ b/src/__tests__/demo/ui-controls.test.ts
@@ -83,7 +83,7 @@ describe('UI Controls', () => {
 
     describe('Control specifications', () => {
         it('should have valid control types', () => {
-            const validTypes = ['number', 'text', 'color', 'select', 'range', 'checkbox', 'textarea'];
+            const validTypes = ['number', 'text', 'color', 'select', 'range', 'checkbox', 'textarea', 'color-map'];
             const rendererControls = ControlsRegistry.getRendererControls();
             
             rendererControls.controls.forEach(control => {
@@ -92,7 +92,7 @@ describe('UI Controls', () => {
         });
 
         it('should have valid output types', () => {
-            const validOutTypes = ['string', 'number', 'boolean', 'array'];
+            const validOutTypes = ['string', 'number', 'boolean', 'array', 'record'];
             const rendererControls = ControlsRegistry.getRendererControls();
             
             rendererControls.controls.forEach(control => {

--- a/src/demo/ui/controls/controls-registry.ts
+++ b/src/demo/ui/controls/controls-registry.ts
@@ -23,11 +23,11 @@ export interface ControlSpec {
     step?: number;
     label: string;
     description?: string;
-    value: string | number | boolean;
+    value: ControlValue;
     category: 'renderer' | 'pattern';
     options?: Array<{ value: string | number | boolean; label: string }>;
-    type: 'number' | 'text' | 'color' | 'select' | 'range' | 'checkbox' | 'textarea';
-    outType: 'string' | 'number' | 'boolean' | 'array';
+    type: 'number' | 'text' | 'color' | 'select' | 'range' | 'checkbox' | 'textarea' | 'color-map';
+    outType: 'string' | 'number' | 'boolean' | 'array' | 'record';
     visibleOn?: Array<{ [key: string]: string | number | boolean }>;
 }
 
@@ -101,7 +101,7 @@ export class ControlsRegistry {
 
     public static parseOutType(
         value: ControlSpec['value'],
-        outType: 'string' | 'number' | 'boolean' | 'array'
+        outType: 'string' | 'number' | 'boolean' | 'array' | 'record'
     ): ControlValue {
         switch (outType) {
             case 'string':
@@ -112,6 +112,8 @@ export class ControlsRegistry {
                 return Boolean(value);
             case 'array':
                 return Array.from(String(value));
+            case 'record':
+                return value as ControlValue;
             default:
                 throw new Error('Unknown outType!');
         }

--- a/src/demo/ui/controls/renderer-control.ts
+++ b/src/demo/ui/controls/renderer-control.ts
@@ -30,7 +30,7 @@ export const controls: RendererControlConfig = {
         category: 'renderer',
         description: 'Font family used for rendering characters.',
     },
-    {
+    { 
         id: 'color',
         label: 'Text color',
         type: 'color',
@@ -38,6 +38,15 @@ export const controls: RendererControlConfig = {
         value: '#ffffff',
         category: 'renderer',
         description: 'Color of the rendered characters.',
+    },
+    {
+        id: 'colorMap',
+        label: 'Color map',
+        type: 'color-map',
+        outType: 'record',
+        value: {},
+        category: 'renderer',
+        description: 'Map characters to individual colors.',
     },
     {
         id: 'animated',

--- a/src/demo/ui/pattern-proxy.ts
+++ b/src/demo/ui/pattern-proxy.ts
@@ -2,7 +2,7 @@ import type { ASCIIRenderer, ASCIIRendererOptions } from '../../rendering/ascii-
 import { ControlsRegistry, type PatternConstructor } from './controls/controls-registry';
 import { DEBOUNCE_INTERVAL_MS } from './constants';
 
-export type ControlValue = string | number | boolean | string[];
+export type ControlValue = string | number | boolean | string[] | Record<string, string>;
 export type ControlChangeCallback = (value: ControlValue) => void;
 
 /**

--- a/src/rendering/ascii-renderer.ts
+++ b/src/rendering/ascii-renderer.ts
@@ -9,6 +9,8 @@ import { type Renderer, createRenderer } from './renderer';
 export interface ASCIIRendererOptions {
     /** Text color for rendered characters */
     color: string;
+    /** Mapping of characters to specific colors */
+    colorMap: Record<string, string>;
     /** Whether animation is enabled */
     animated: boolean;
     /** Animation speed multiplier */
@@ -46,6 +48,7 @@ export interface ASCIIRendererConstructor {
 
 const DEFAULT_OPTIONS: ASCIIRendererOptions = {
     color: '#3e3e80ff',
+    colorMap: {},
     fontSize: 32,
     fontFamily: 'monospace',
     backgroundColor: '#181818ff',

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -99,38 +99,52 @@ export class Canvas2DRenderer implements Renderer {
             this._context.clip();
         }
 
+        const defaultColor = this._options.color;
+        const colorMap = this._options.colorMap;
+        let currentColor = defaultColor;
+        let currentAlpha = 1;
+        this._context.fillStyle = defaultColor;
+
         for (const char of characters) {
-            if (char.x < 0 || char.x >= region.canvasWidth || 
-                char.y < 0 || char.y >= region.canvasHeight) 
+            if (char.x < 0 || char.x >= region.canvasWidth ||
+                char.y < 0 || char.y >= region.canvasHeight)
                 continue;
 
-            if (char.opacity !== undefined) 
-                this._context.globalAlpha = char.opacity;
+            const targetAlpha = char.opacity === undefined ? 1 : char.opacity;
 
-            if (char.color) 
-                this._context.fillStyle = char.color;
-            
+            if (targetAlpha !== currentAlpha) {
+                this._context.globalAlpha = targetAlpha;
+                currentAlpha = targetAlpha;
+            }
+
+            const charColor = char.color || colorMap[char.char] || defaultColor;
+
+            if (charColor !== currentColor) {
+                this._context.fillStyle = charColor;
+                currentColor = charColor;
+            }
+
             if (char.scale !== undefined || char.rotation !== undefined) {
                 this._context.save();
                 this._context.translate(char.x + region.charWidth / 2, char.y + region.charHeight / 2);
 
-                if (char.rotation !== undefined) 
+                if (char.rotation !== undefined)
                     this._context.rotate(char.rotation);
-                
-                if (char.scale !== undefined) 
+
+                if (char.scale !== undefined)
                     this._context.scale(char.scale, char.scale);
-                
+
                 this._context.fillText(char.char, -region.charWidth / 2, -region.charHeight / 2);
                 this._context.restore();
-            } else 
+            } else
                 this._context.fillText(char.char, char.x, char.y);
-
-            if (char.opacity !== undefined) 
-                this._context.globalAlpha = 1;
-
-            if (char.color) 
-                this._context.fillStyle = this._options.color;
         }
+
+        if (currentAlpha !== 1)
+            this._context.globalAlpha = 1;
+
+        if (currentColor !== defaultColor)
+            this._context.fillStyle = defaultColor;
 
         if (needsClipping) 
             this._context.restore();


### PR DESCRIPTION
## Summary
- optimize 2D canvas rendering by caching color and opacity and supporting per-character color mapping
- expose optional `colorMap` renderer option to color groups of characters and ensure it is always defined
- cover color map rendering in tests
- allow editing the renderer color map through demo controls with add/remove UI

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68950ee3a518832babc72ea99f55d03e